### PR TITLE
set end date for Hortense cooling problems that started 28 March 2023

### DIFF
--- a/incidents/hortense_20230330.yml
+++ b/incidents/hortense_20230330.yml
@@ -1,7 +1,7 @@
 meta_data:
   title: Unstable cooling of Tier1 Hortense
   start_date: 2023-03-28 17:20:00
-  end_date: 
+  end_date: 2023-04-07 17:00:00
   affected: tier1_compute
   level: high
   planned: no


### PR DESCRIPTION
@stdweird As far as I know this problem is fixed now.

Let me know if the end date should be tweaked, but it doesn't matter much I guess, it's mostly about removing the scary looking messages that are still there at https://status.vscentrum.be/tier1_compute.html