### PR TITLE
Update incident kul_20240125

### DIFF
--- a/incidents/kul_20240125.yml
+++ b/incidents/kul_20240125.yml
@@ -1,7 +1,7 @@
 meta_data:
   title: Globus collection VSC KU Leuven Tier-2 scratch not accessible.
   start_date: 2024-01-25 00:00:00
-  end_date:  
+  end_date:  2024-01-26 13:15:00
   affected: tier2_leuven
   level: medium
   planned: no


### PR DESCRIPTION
This PR is to update the incident kul_20240125 (an issue in the KU leuven Tier-2 Scratch end point) for the Globus service.