### PR TITLE
Fix filename overlap

### DIFF
--- a/incidents/ugent_20260516.yml
+++ b/incidents/ugent_20260516.yml
@@ -1,0 +1,16 @@
+meta_data:
+  title: Login nodes unavailable due to critical security vulnerability
+  start_date: 2026-05-16 12:37:00
+  end_date:
+  affected: tier2_gent, tier1_compute
+  level: high
+  planned: no
+content: >
+  <p>
+  Due to a critical security vulnerability, access to the HPC-UGent Tier-2 and VSC Tier-1 Hortense login nodes was closed
+  for all VSC accounts on Saturday 16 May 2026 at 12:37 CEST.
+  </p>
+  <p>
+  Access to both the HPC-UGent Tier-2 and VSC Tier-1 Hortense infrastructure will remain unavailable
+  until a fix has been deployed.
+  </p>

--- a/incidents/ugent_20260518.yml
+++ b/incidents/ugent_20260518.yml
@@ -1,16 +1,17 @@
 meta_data:
-  title: Login nodes unavailable due to critical security vulnerability
-  start_date: 2026-05-16 12:37:00
-  end_date:
-  affected: tier2_gent, tier1_compute
+  title: HPC-UGent Tier2 maintenance
+  start_date: 2026-05-18 08:00:00
+  end_date: 2026-05-20 18:00:00
+  affected: tier2_gent
   level: high
-  planned: no
+  planned: yes
 content: >
   <p>
-  Due to a critical security vulnerability, access to the HPC-UGent Tier-2 and VSC Tier-1 Hortense login nodes was closed
-  for all VSC accounts on Saturday 16 May 2026 at 12:37 CEST.
+  We will update the scheduler (slurm) and some drivers (for GPUS) and the kernel for security updates.
   </p>
   <p>
-  Access to both the HPC-UGent Tier-2 and VSC Tier-1 Hortense infrastructure will remain unavailable
-  until a fix has been deployed.
+  The following infrastructure and services will be unavailable during this period: The whole Tier-2 system including all workernodes as well as login and debug nodes, and the Tier-2 filesystem.
+  </p>
+  <p>
+  Please be aware that during the maintenance period, you will not be able to access any data located on Tier-2 system.
   </p>


### PR DESCRIPTION
Rename file for UGent vulnerability incident (20260516 instead of 20260518) and re-add planned UGent Tier-2 maintenance which was overwritten